### PR TITLE
Url de api de produção padrão a ser seguida

### DIFF
--- a/front/src/app/pesquisa/services/projetos.service.ts
+++ b/front/src/app/pesquisa/services/projetos.service.ts
@@ -8,7 +8,7 @@ import { Projeto } from './../models/projeto.interface';
 
 @Injectable()
 export class ProjetosService {
-  private static readonly ENDPONIT = `${environment.api.url}/projetos`;
+  private static readonly ENDPONIT = `${environment.api.url}/pesquisa/projetos`;
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
- Verificar um modo do json-server seguir esta configuração também.

Issue: #479
Descrição: Url de api de produção padrão alterada para api/<nome_do_modulo>/<nome_produto>
Exemplo: /pesquisa/projetos
